### PR TITLE
Add updating of radius for non-static light sources

### DIFF
--- a/example/ball.script
+++ b/example/ball.script
@@ -4,6 +4,8 @@ function init(self)
 	msg.post(".", "acquire_input_focus")
 	msg.post("camera", "acquire_camera_focus")
 	self.direction = vmath.vector3(0)
+
+	go.animate("/blue_light#lightsource", "radius", go.PLAYBACK_LOOP_PINGPONG, 256, go.EASING_INOUTQUAD, 4.0)
 end
 
 function update(self, dt)

--- a/example/example.collection
+++ b/example/example.collection
@@ -216,8 +216,8 @@ collection_instances {
   id: "ball"
   collection: "/example/ball.collection"
   position {
-    x: 0.0
-    y: 0.0
+    x: 48.0
+    y: 44.0
     z: 0.0
   }
   rotation {

--- a/lights/lights.lua
+++ b/lights/lights.lua
@@ -203,4 +203,8 @@ function M.set_angle(id, angle)
 	lights[id].angle = angle
 end
 
+function M.set_color(id, color)
+	lights[id].color = color
+end
+
 return M

--- a/lights/lightsource.script
+++ b/lights/lightsource.script
@@ -94,5 +94,6 @@ function update(self, dt)
 		lights.set_angle(self.light, update_angle(self.arc_angle))
 		lights.set_position(self.light, go.get_world_position())
 		lights.set_light_radius(self.light, self.radius)
+		lights.set_color(self.light, self.color)
 	end
 end

--- a/lights/lightsource.script
+++ b/lights/lightsource.script
@@ -93,5 +93,6 @@ function update(self, dt)
 	if not self.static then
 		lights.set_angle(self.light, update_angle(self.arc_angle))
 		lights.set_position(self.light, go.get_world_position())
+		lights.set_light_radius(self.light, self.radius)
 	end
 end


### PR DESCRIPTION
Just a small update here.

I added a line in the `update()` function of `lightsource.script` that also updates the light `radius` for non-static objects. For some reason this was missing.

I have also updated the example collection to showcase this by animating the blue ball's light radius.

![Animation](https://user-images.githubusercontent.com/29335643/152635836-16ba65d6-e0d0-44b2-a4cb-d8fb12be77fd.gif)

---

Edit: I've also added the same for the `color` property.
